### PR TITLE
Fix compile flags for Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 
 # Linux
 ifeq ($(UNAME),Linux)
-LFLAGS = -lm -lGLEW -lglfw3 lGL -lGLU
+LFLAGS = -lm -lGLEW -lglfw -lGL -lGLU
 clean:
 	-rm $(ALL)
 endif


### PR DESCRIPTION
Fixes typos in Linux compile flags for GCC.
Correct name for **GLFW** library is not `glfw3` but `glfw`. There was also a typo (missing `-l`) for **GL**.

(Tested on Debian Stable)
