### PR TITLE
Fix incorrect swapping of channels when using TGA image with alpha channel

### DIFF
--- a/tga.h
+++ b/tga.h
@@ -207,7 +207,7 @@ public:
     } else {
       std::memcpy(data, image, nbytes);
 
-      // swap RGB into BRG
+      // swap RGB into BGR
       for (unsigned long i = 0; i < nbytes; i+=bpp)
         std::swap(data[i], data[i+2]); 
     }

--- a/tga.h
+++ b/tga.h
@@ -208,7 +208,7 @@ public:
       std::memcpy(data, image, nbytes);
 
       // swap RGB into BRG
-      for (unsigned long i = 0; i < nbytes; i+=3)
+      for (unsigned long i = 0; i < nbytes; i+=bpp)
         std::swap(data[i], data[i+2]); 
     }
   }


### PR DESCRIPTION
Passing buffer with RGBA data and 4 as bytes per pixel to constructor results in corrupted image.
