### PR TITLE
Fix build for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,13 +32,17 @@ if (MINGW)
 elseif (MSVC)
   set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${CMAKE_SOURCE_DIR}/dependencies/include/")
   set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${CMAKE_SOURCE_DIR}/dependencies/lib/vc2015")
-  set(STRICT_COMPILE_FLAGS)
+  set(STRICT_COMPILE_FLAGS "-Wall")
 endif ()
 
 # Warnings for Debug mode
 option(USE_STRICT_COMPILE_WARNINGS "Use strict compilation warnings in debug mode." ON)
-# These compile flags should apply for GCC and Clang compilers
-set(STRICT_COMPILE_FLAGS "-Wpedantic -Wall -Wno-c++98-compat -Wfloat-equal -Wextra -Wsign-promo -Wsign-compare -Wconversion -Wno-sign-conversion -Wno-unused-parameter")
+
+if (NOT STRICT_COMPILE_FLAGS)
+  # These compile flags should apply for GCC and Clang compilers
+  set(STRICT_COMPILE_FLAGS "-Wpedantic -Wall -Wno-c++98-compat -Wfloat-equal -Wextra -Wsign-promo -Wsign-compare -Wconversion -Wno-sign-conversion -Wno-unused-parameter")
+endif()
+
 if (USE_STRICT_COMPILE_WARNINGS)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${STRICT_COMPILE_FLAGS}")
 endif ()

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A good alternative IDE for Windows is [QTCreator][7] that should work out of the
 Running the examples
 ----
 
-When using CLion you should first build the `run_install` target. This will generate a installation with all resources present in a `{project_root}/_install` folder. After that set the working direcotry to this folder for each target manually.
+When using CLion you should first build the `run_install` target. This will generate a installation with all resources present in a `{project_root}/_install` folder. After that set the working directory to this folder for each target manually.
 
 Common pitfalls
 ---


### PR DESCRIPTION
When building with MSVC compiler with strict compilation on, there is variable **STRICT_COMPILE_FLAGS** that is being overriden by flags for GCC\Clang compiler and since msvc does not have most of those flags, it does not build.
