### PR TITLE
wrong size of ibo buffer

### DIFF
--- a/src/task6_bezier_surface/task6_bezier_surface.cpp
+++ b/src/task6_bezier_surface/task6_bezier_surface.cpp
@@ -112,7 +112,7 @@ public:
     // Copy indices to gpu
     glGenBuffers(1, &ibo);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ibo);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, mesh.size() * sizeof(GLuint), mesh.data(), GL_STATIC_DRAW);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, mesh.size() * sizeof(GLuint) * 3, mesh.data(), GL_STATIC_DRAW);
 
   };
   // Clean up


### PR DESCRIPTION
vo velkost ibo bufferu nebol zohladneny pocet indexov vo face strukture co malo za nasledok vykreslenie len tretinu trojuholnikov z mesh-u. Kedze to nebolo pod TODO tak nepozorny riesitel mohol tento nedostatok prehliadnut.